### PR TITLE
Hi Sean. This is Xiangchao. I Created data-converge-revised. The bc c…

### DIFF
--- a/Data-converge-revised
+++ b/Data-converge-revised
@@ -1,0 +1,82 @@
+#!/bin/bash
+# vaspup2.0 - Seán Kavanagh (sean.kavanagh.19@ucl.ac.uk), 2023
+# revised by Xiangchao Meng (xiangchao.meng.22@ucl.ac.uk), 08/10/2023
+rm -f data # delete data file if exists
+
+n=0
+shopt -s extglob
+custom_tab='  '
+
+# The bc command in line 43 is not compatible with the out put of checkforce command in sci-form, i.e., bc can't recognise output as 1e-05. This sci2dec() function was added to convert sci-form to numerical form.
+sci2dec() {
+    printf "%.10f" "$1"
+}
+
+if ! [ -x "$(command -v checkforce)" ]
+then 
+    echo -e "checkforce (from https://github.com/bjmorgan/VASP-Utilities) is not on PATH, will not check force convergence."
+fi
+
+for i in {!(*_*),*_*}/CONTCAR; do
+    if ! [[ $i == "*_*/CONTCAR" ]]
+    then
+    if ! [[ $i == "!(*_*)/CONTCAR" ]]
+    then
+    if [[ $i == *k_* ]]; then
+        spacing="\t"
+    else
+        spacing="\t\t"
+    fi
+
+    folder=${i/CONTCAR/}
+    name=${folder//[\/]/} # folder name without slashes
+
+    n_atoms=$(sed '7q;d' $i | awk '{sum=0; for (i=1; i<=NF; i++) { sum+= $i } print sum}') # sum over row 7 of the CONTCAR
+    energy_total=$(grep TOTEN $folder/OUTCAR | awk '{print $5}' | tail -1 | tr -d '\n') # tr is to remove the trailing newline
+    energy_per_atom=$(echo "scale = 7; $energy_total / $n_atoms" | bc)
+    nelm=$(grep NELM $folder/OUTCAR | awk '{print $3}' | head -1 | tr -d ";" )
+    n_iter=$(grep Iteration $folder/OUTCAR | awk '{print $4}' | tail -1 | tr -d ")" )
+    
+    if [ -x "$(command -v checkforce)" ] && [ "$n" -ne "0" ]
+    then 
+        residual_force=$(sci2dec $("checkforce" -c 0 $folder/OUTCAR | awk '/remainder/ {print $NF}'))
+        force_diff=$(echo "scale = 7; ($force_prev - $residual_force) * 1000" | bc)  # meV/Angstrom averaged
+        force_prev=$residual_force
+    elif [ -x "$(command -v checkforce)" ]
+    then 
+        force_prev=$(sci2dec $("checkforce" -c 0 $folder/OUTCAR | awk '/remainder/ {print $NF}'))
+    fi
+
+    if [ "$n_iter" == "$nelm" ]; then 
+        echo -e "Electronic self-consistency was not reached for ${name} (i.e. NELM reached),\nconvergence results likely unreliable."
+    fi
+
+    echo -n -e "$name$spacing$energy_total\t$energy_per_atom" >> data
+
+    if [ "$n" -ne "0" ]; then # the first line will not have a difference therefore ignore it
+        energy_prev=$(sed "${n}q;d" data | awk '{print $3}')
+        energy_diff=$(echo "scale = 7; ($energy_prev - $energy_per_atom) * 1000" | bc)
+        if [ -x "$(command -v checkforce)" ]
+        then 
+            echo -n -e "\t${custom_tab}$energy_diff\t\t${custom_tab}$force_diff" >> data
+        else
+            echo -n -e "\t${custom_tab}$energy_diff" >> data
+        fi
+    fi
+
+    echo -n -e "\n" >> data
+    let n=n+1
+    fi
+    fi
+    
+done
+echo -e "Note, if your system is magnetic, you should use data-converge-magnetic.\n"
+if [ -x "$(command -v checkforce)" ]
+then
+    echo "Directory:     Total Energy/eV: (per atom): Difference (meV/atom): Average Force Difference (meV/Å):" > header
+else
+    echo "Directory:     Total Energy/eV: (per atom): Difference (meV/atom):" > header
+fi
+cat header data >&1 | tee Convergence_Data
+rm -f header
+rm -f data


### PR DESCRIPTION
… command cannot recognise the output of `checkforce` in sci-form. I added a function to convert sci-output to common numerical forms.

i was doing convergence test of Li2S on vasp and `checkforce` gave remainder such as 1e-05. Such forms cannot be recognised by `bc` command. Therefore, a new function was defined within the `data-converge` to convert sci-forms to numerical forms. I did not check `data-converge-magnet`. There might be the same issue.